### PR TITLE
Simplify sorting

### DIFF
--- a/examples/alpha/app.rs
+++ b/examples/alpha/app.rs
@@ -171,11 +171,10 @@ impl<
             material: Material { alpha: i as f32 / 10.0 },
         });
 
-        let mut phase = gfx_phase::Phase::new_cached(
+        let phase = gfx_phase::Phase::new_cached(
             "Main",
             Technique::new(&mut device),
         );
-        phase.sort.push(gfx_phase::Sort::BackToFront);
 
         let aspect = w as f32 / h as f32;
         let proj = perspective(deg(90.0f32), aspect, 1.0, 10.0);
@@ -218,6 +217,7 @@ impl<D: gfx::Device> App<D> {
             self.phase.enqueue(ent, view_info, &mut self.context).unwrap();
         }
         
+        self.phase.queue.sort(gfx_phase::Object::back_to_front);
         self.phase.flush(&self.frame, &mut self.context, &mut self.renderer).unwrap();
         self.device.submit(self.renderer.as_buffer());
     }

--- a/examples/alpha/main.rs
+++ b/examples/alpha/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, custom_attribute)]
+#![feature(core, plugin, custom_attribute)]
 #![plugin(gfx_macros)]
 
 extern crate cgmath;

--- a/examples/beta/app.rs
+++ b/examples/beta/app.rs
@@ -192,11 +192,10 @@ impl<
         //let mut harness = gfx_scene::PhaseHarness::<gfx_device_gl::GlDevice, _>::
         //    new(scene, device.create_renderer());
 
-        let mut phase = gfx_phase::Phase::new(
+        let phase = gfx_phase::Phase::new(
             "Main",
             Technique::new(&mut device),
         );
-        phase.sort.push(gfx_phase::Sort::Program);
         //harness.phases.push(Box::new(phase));
         //harness.clear = Some(clear_data);
 

--- a/examples/beta/app.rs
+++ b/examples/beta/app.rs
@@ -170,6 +170,7 @@ impl<
         let slice = mesh.to_slice(gfx::PrimitiveType::TriangleStrip);
 
         let mut scene = gfx_scene::Scene::new(World);
+        scene.sort.push(gfx_phase::Sort::Program);
         //scene.cull_frustum = false;
         let num = 10usize;
         let entities = (0..num).map(|i| {

--- a/examples/beta/main.rs
+++ b/examples/beta/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, custom_attribute)]
+#![feature(core, plugin, custom_attribute)]
 #![plugin(gfx_macros)]
 
 extern crate cgmath;

--- a/src/phase/lib.rs
+++ b/src/phase/lib.rs
@@ -12,7 +12,7 @@ use std::fmt::Debug;
 use std::hash::Hash;
 use std::marker::PhantomFn;
 
-pub use self::phase::{Object, FlushError, QueuePhase, FlushPhase,
+pub use self::phase::{Sort, Object, FlushError, QueuePhase, FlushPhase,
                       AbstractPhase, Phase, CachedPhase};
 
 /// Abstract material.

--- a/src/phase/lib.rs
+++ b/src/phase/lib.rs
@@ -12,8 +12,8 @@ use std::fmt::Debug;
 use std::hash::Hash;
 use std::marker::PhantomFn;
 
-pub use self::phase::{FlushError, QueuePhase, FlushPhase,
-                      AbstractPhase, Sort, Phase, CachedPhase};
+pub use self::phase::{Object, FlushError, QueuePhase, FlushPhase,
+                      AbstractPhase, Phase, CachedPhase};
 
 /// Abstract material.
 pub trait Material: PhantomFn<Self> {}

--- a/src/phase/phase.rs
+++ b/src/phase/phase.rs
@@ -69,13 +69,13 @@ impl<S: PartialOrd, K, P: gfx::shade::ShaderParam> Object<S, K, P> {
     /// Order by depth, front-to-back. Useful for opaque objects that updates
     /// the depth buffer. The front stuff will occlude more pixels, leaving
     /// less work to be done for the farther objects.
-    pub fn order_front_to_back(a: &Object<S, K, P>, b: &Object<S, K, P>) -> Ordering {
+    pub fn front_to_back(a: &Object<S, K, P>, b: &Object<S, K, P>) -> Ordering {
         a.cmp_depth(b)
     }
 
     /// Order by depth, back-to-front. Useful for transparent objects, since
     /// blending should take into account everything that lies behind.
-    pub fn order_back_to_front(a: &Object<S, K, P>, b: &Object<S, K, P>) -> Ordering {
+    pub fn back_to_front(a: &Object<S, K, P>, b: &Object<S, K, P>) -> Ordering {
         b.cmp_depth(a)
     }
 }

--- a/src/phase/phase.rs
+++ b/src/phase/phase.rs
@@ -34,8 +34,8 @@ pub trait AbstractPhase<R: gfx::Resources, C: gfx::CommandBuffer<R>, E, V: ::ToD
 {}
 
 /// A rendering object, encapsulating the batch and additional info
-/// needed for sorting. It is only exposed for the matter of sorting,
-/// and accessed by immutable references by the user.
+/// needed for sorting. It is only exposed for this matter and
+/// accessed by immutable references by the user.
 #[allow(missing_docs)]
 pub struct Object<S, K, P: gfx::shade::ShaderParam> {
     pub batch: gfx::batch::CoreBatch<P>,
@@ -80,8 +80,8 @@ impl<S: PartialOrd, K, P: gfx::shade::ShaderParam> Object<S, K, P> {
     }
 }
 
-/// Phase is doing draw call accumulating and sorting,
-/// based a given technique.
+/// Phase is doing batch construction, accumulation, and memorization,
+/// based on a given technique.
 pub struct Phase<
     R: gfx::Resources,
     M: ::Material,

--- a/src/queue/lib.rs
+++ b/src/queue/lib.rs
@@ -60,7 +60,7 @@ impl<T> Queue<T> {
     /// Sort the draw queue.
     pub fn sort<F: Sized + Fn(&T, &T) -> std::cmp::Ordering>(&mut self, fun: F) {
         self.update();
-        let objects = self.objects.as_slice();
+        let objects = &self.objects;
         self.indices.sort_by(|&Id(a, _), &Id(b, _)|
             fun(&objects[a as usize], &objects[b as usize])
         );
@@ -70,7 +70,7 @@ impl<T> Queue<T> {
     pub fn iter<'a>(&'a self) -> QueueIter<'a, T> {
         assert!(self.is_ready());
         QueueIter {
-            objects: self.objects.as_slice(),
+            objects: &self.objects,
             id_iter: self.indices.iter(),
         }
     }

--- a/src/queue/lib.rs
+++ b/src/queue/lib.rs
@@ -1,4 +1,3 @@
-#![feature(core)]
 #![deny(missing_docs)]
 
 //! Generic draw queue that keeps item ordering, supposedly minimizing

--- a/src/scene/lib.rs
+++ b/src/scene/lib.rs
@@ -2,7 +2,7 @@
 
 //! Scene infrastructure to be used with Gfx phases.
 
-extern crate "gfx_phase" as phase;
+extern crate gfx_phase as phase;
 extern crate gfx;
 extern crate cgmath;
 


### PR DESCRIPTION
This PR exposes the queue, allowing the user to sort as he will. `Object` gets exposed as well, and it provides helper methods for back-to-front and front-to-back ordering.