### PR TITLE
Support for custom ordering function

### DIFF
--- a/src/phase/lib.rs
+++ b/src/phase/lib.rs
@@ -13,7 +13,7 @@ use std::hash::Hash;
 use std::marker::PhantomFn;
 
 pub use self::phase::{Sort, Object, FlushError, QueuePhase, FlushPhase,
-                      AbstractPhase, Phase, CachedPhase};
+                      Ordered, AbstractPhase, Phase, CachedPhase};
 
 /// Abstract material.
 pub trait Material: PhantomFn<Self> {}


### PR DESCRIPTION
This is quite clunky, actually, but I haven't found a better way to support custom ordering for generic base interfaces (`AbstractPhase`, `AbstractScene`).