### PR TITLE
Culling iterator

### DIFF
--- a/examples/alpha/app.rs
+++ b/examples/alpha/app.rs
@@ -118,15 +118,10 @@ struct Entity<R: gfx::Resources> {
     material: Material,
 }
 
-impl<R: gfx::Resources> gfx_phase::Entity<R, Material> for Entity<R> {
-    fn get_material(&self) -> &Material { &self.material }
-    fn get_mesh(&self) -> (&gfx::Mesh<R>, &gfx::Slice<R>) { (&self.mesh, &self.slice) }
-}
-
 //----------------------------------------
 
 pub struct App<R: gfx::Resources> {
-    phase: gfx_phase::CachedPhase<R, Material, ViewInfo, Technique<R>, Entity<R>>,
+    phase: gfx_phase::CachedPhase<R, Material, ViewInfo, Technique<R>>,
     entities: Vec<Entity<R>>,
     proj_view: Matrix4<f32>,
 }
@@ -195,7 +190,7 @@ impl<R: gfx::Resources> App<R> {
                 3.0 * angle.cos(), 0.0, 3.0 * angle.sin()
             ));
             let view_info = ViewInfo(self.proj_view.mul_m(&model));
-            self.phase.enqueue(ent, view_info).unwrap();
+            self.phase.enqueue(&ent.mesh, &ent.slice, &ent.material, view_info).unwrap();
         }
         
         self.phase.flush(stream).unwrap();

--- a/examples/alpha/app.rs
+++ b/examples/alpha/app.rs
@@ -93,7 +93,7 @@ for Technique<R> {
         Some(mat.alpha < 1.0)
     }
 
-    fn compile<'a>(&'a self, kernel: bool, space: ViewInfo)
+    fn compile<'a>(&'a self, kernel: bool, space: &ViewInfo)
                    -> gfx_phase::TechResult<'a, R, Params<R>> {
         (   &self.program,
             Params {
@@ -190,7 +190,7 @@ impl<R: gfx::Resources> App<R> {
                 3.0 * angle.cos(), 0.0, 3.0 * angle.sin()
             ));
             let view_info = ViewInfo(self.proj_view.mul_m(&model));
-            self.phase.enqueue(&ent.mesh, &ent.slice, &ent.material, view_info).unwrap();
+            self.phase.enqueue(&ent.mesh, &ent.slice, &ent.material, &view_info).unwrap();
         }
         
         self.phase.flush(stream).unwrap();

--- a/examples/beta/app.rs
+++ b/examples/beta/app.rs
@@ -88,7 +88,7 @@ for Technique<R> {
         Some(())
     }
 
-    fn compile<'a>(&'a self, _: (), _: ViewInfo)
+    fn compile<'a>(&'a self, _: (), _: &ViewInfo)
                    -> gfx_phase::TechResult<'a, R, Params<R>> {
         (   &self.program,
             Params {

--- a/examples/beta/app.rs
+++ b/examples/beta/app.rs
@@ -144,9 +144,7 @@ impl gfx_scene::World for World {
 //----------------------------------------
 
 pub struct App<R: gfx::Resources> {
-    phase: gfx_phase::Phase<R, Material, ViewInfo, Technique<R>,
-                            gfx_scene::Entity<R, Material, World, cgmath::Aabb3<f32>>,
-                            ()>,
+    phase: gfx_phase::Phase<R, Material, ViewInfo, Technique<R>, ()>,
     scene: gfx_scene::Scene<R, Material, World, cgmath::Aabb3<f32>, cgmath::Ortho<f32>, ViewInfo>,
     camera: gfx_scene::Camera<cgmath::Ortho<f32>, <World as gfx_scene::World>::NodePtr>,
 }

--- a/examples/beta/app.rs
+++ b/examples/beta/app.rs
@@ -149,7 +149,16 @@ pub struct App<R: gfx::Resources> {
     camera: gfx_scene::Camera<cgmath::Ortho<f32>, <World as gfx_scene::World>::NodePtr>,
 }
 
-impl<R: gfx::Resources> App<R> {
+impl<R: gfx::Resources + 'static> App<R> where
+    R::Buffer: 'static,
+    R::ArrayBuffer: 'static,
+    R::Shader: 'static,
+    R::Program: 'static,
+    R::FrameBuffer: 'static,
+    R::Surface: 'static,
+    R::Texture: 'static,
+    R::Sampler: 'static,
+{
     pub fn new<F: gfx::Factory<R>>(factory: &mut F) -> App<R> {
         let vertex_data = [
             Vertex::new(0, 1),

--- a/src/phase/lib.rs
+++ b/src/phase/lib.rs
@@ -49,7 +49,7 @@ pub trait Technique<R: gfx::Resources, M: Material, V: ToDepth> {
     fn test(&self, &gfx::Mesh<R>, &M) -> Option<Self::Kernel>;
     /// Compile a given kernel by producing a program, parameter block,
     /// a draw state, and an optional instancing data.
-    fn compile<'a>(&'a self, Self::Kernel, V)
+    fn compile<'a>(&'a self, Self::Kernel, &V)
                    -> TechResult<'a, R, Self::Params>;
     /// Fix the shader parameters, using an updated material and view info.
     fn fix_params(&self, &M, &V, &mut Self::Params);

--- a/src/phase/lib.rs
+++ b/src/phase/lib.rs
@@ -54,11 +54,3 @@ pub trait Technique<R: gfx::Resources, M: Material, V: ToDepth> {
     /// Fix the shader parameters, using an updated material and view info.
     fn fix_params(&self, &M, &V, &mut Self::Params);
 }
-
-/// Abstract entity.
-pub trait Entity<R: gfx::Resources, M: Material> {
-    /// Obtain an associated material.
-    fn get_material(&self) -> &M;
-    /// Obtain an associated mesh.
-    fn get_mesh(&self) -> (&gfx::Mesh<R>, &gfx::Slice<R>);
-}

--- a/src/phase/phase.rs
+++ b/src/phase/phase.rs
@@ -2,7 +2,6 @@
 
 use std::cmp::Ordering;
 use std::collections::HashMap;
-use std::marker::PhantomData;
 use draw_queue;
 use gfx;
 use mem;
@@ -11,11 +10,12 @@ use mem;
 pub type FlushError = gfx::DrawError<gfx::batch::OutOfBounds>;
 
 /// An abstract rendering phase.
-pub trait AbstractPhase<R: gfx::Resources, E, V: ::ToDepth> {
+pub trait AbstractPhase<R: gfx::Resources, M, V: ::ToDepth> {
     /// Check if it makes sense to draw this entity.
-    fn test(&self, &E) -> bool;
+    fn test(&self, &gfx::Mesh<R>, &M) -> bool;
     /// Add an entity to the queue.
-    fn enqueue(&mut self, &E, V) -> Result<(), gfx::batch::Error>;
+    fn enqueue(&mut self, &gfx::Mesh<R>, &gfx::Slice<R>, &M, V)
+               -> Result<(), gfx::batch::Error>;
     /// Flush the queue into a given stream.
     fn flush<S: gfx::Stream<R>>(&mut self, stream: &mut S)
              -> Result<(), FlushError>;
@@ -106,7 +106,6 @@ pub struct Phase<
     M: ::Material,
     V: ::ToDepth,
     T: ::Technique<R, M, V>,
-    E,  // Entity
     Y,  // Memory
 >{
     /// Phase name.
@@ -121,8 +120,6 @@ pub struct Phase<
     queue: draw_queue::Queue<Object<V::Depth, T::Kernel, T::Params>>,
     /// Batch context.
     context: gfx::batch::Context<R>,
-    /// Dummy Entity use.
-    dummy: PhantomData<E>,
 }
 
 /// Memory typedef using a `HashMap`.
@@ -141,18 +138,16 @@ pub type CachedPhase<
     M: ::Material,
     V: ::ToDepth,
     T: ::Technique<R, M, V>,
-    E,
-> = Phase<R, M, V, T, E, CacheMap<R, M, V, T>>;
+> = Phase<R, M, V, T, CacheMap<R, M, V, T>>;
 
 impl<
     R: gfx::Resources,
     M: ::Material,
     V: ::ToDepth,
     T: ::Technique<R, M, V>,
-    E,
-> Phase<R, M, V, T, E, ()> {
+> Phase<R, M, V, T, ()> {
     /// Create a new phase from a given technique.
-    pub fn new(name: &str, tech: T) -> Phase<R, M, V, T, E, ()> {
+    pub fn new(name: &str, tech: T) -> Phase<R, M, V, T, ()> {
         Phase {
             name: name.to_string(),
             technique: tech,
@@ -160,13 +155,12 @@ impl<
             memory: (),
             queue: draw_queue::Queue::new(),
             context: gfx::batch::Context::new(),
-            dummy: PhantomData,
         }
     }
 
     /// Enable sorting of rendered objects.
     pub fn with_sort(self, fun: OrderFun<V::Depth, T::Kernel, T::Params>)
-                     -> Phase<R, M, V, T, E, ()> {
+                     -> Phase<R, M, V, T, ()> {
         Phase {
             sort: Some(fun),
             .. self
@@ -174,7 +168,7 @@ impl<
     }
 
     /// Enable caching of created render objects.
-    pub fn with_cache(self) -> CachedPhase<R, M, V, T, E> {
+    pub fn with_cache(self) -> CachedPhase<R, M, V, T> {
         Phase {
             name: self.name,
             technique: self.technique,
@@ -182,7 +176,6 @@ impl<
             memory: HashMap::new(),
             queue: self.queue,
             context: self.context,
-            dummy: self.dummy,
         }
     }
 }
@@ -191,26 +184,23 @@ impl<
     R: gfx::Resources,
     M: ::Material,
     V: ::ToDepth + Copy,
-    E: ::Entity<R, M>,
     T: ::Technique<R, M, V>,
     Y: mem::Memory<(T::Kernel, gfx::Mesh<R>),
         Object<V::Depth, T::Kernel, T::Params>
     >,
->AbstractPhase<R, E, V> for Phase<R, M, V, T, E, Y> where
+>AbstractPhase<R, M, V> for Phase<R, M, V, T, Y> where
     T::Params: Clone,
     <T::Params as gfx::shade::ShaderParam>::Link: Copy,
 {
-    fn test(&self, entity: &E) -> bool {
-        self.technique.test(entity.get_mesh().0, entity.get_material())
-                      .is_some()
+    fn test(&self, mesh: &gfx::Mesh<R>, material: &M) -> bool {
+        self.technique.test(mesh, material).is_some()
     }
 
-    fn enqueue(&mut self, entity: &E, view_info: V)
+    fn enqueue(&mut self, orig_mesh: &gfx::Mesh<R>, slice: &gfx::Slice<R>,
+               material: &M, view_info: V)
                -> Result<(), gfx::batch::Error> {
-        let kernel = self.technique.test(
-            entity.get_mesh().0, entity.get_material())
-            .unwrap(); //TODO?
-        let (orig_mesh, slice) = entity.get_mesh();
+        let kernel = self.technique.test(orig_mesh, material)
+                                   .unwrap(); //TODO?
         let depth = view_info.to_depth();
         let key = (kernel, orig_mesh.clone()); //TODO: avoid clone() here
         // Try recalling from memory
@@ -219,8 +209,7 @@ impl<
                 o.slice = slice.clone();
                 o.depth = depth;
                 assert_eq!(o.kernel, kernel);
-                self.technique.fix_params(entity.get_material(),
-                                          &view_info, &mut o.params);
+                self.technique.fix_params(material, &view_info, &mut o.params);
                 self.queue.objects.push(o);
                 return Ok(())
             },
@@ -230,8 +219,7 @@ impl<
         // Compile with the technique
         let (program, mut params, inst_mesh, state) =
             self.technique.compile(kernel, view_info);
-        self.technique.fix_params(entity.get_material(),
-                                  &view_info, &mut params);
+        self.technique.fix_params(material, &view_info, &mut params);
         let mut temp_mesh = gfx::Mesh::new(orig_mesh.num_vertices);
         let mesh = match inst_mesh {
             Some(m) => {

--- a/src/scene/cull.rs
+++ b/src/scene/cull.rs
@@ -136,45 +136,6 @@ impl<S: cgmath::BaseFloat, B: cgmath::Bound<S>> Culler<S, B> for Frustum<S, B> {
         bound.relate_clip_space(mvp)
     }
 }
-/*
-impl<'a, R, M, V, I> ::AbstractScene<R> for I where
-    R: gfx::Resources,
-    R::Buffer: 'a,
-    R::ArrayBuffer: 'a,
-    R::Shader: 'a,
-    R::Program: 'a,
-    R::FrameBuffer: 'a,
-    R::Surface: 'a,
-    R::Texture: 'a,
-    R::Sampler: 'a,
-    V, gfx_phase::ToDepth,
-    I: Iterator<Item = CullEntity<'a, V, R, M>>,
-{
-    type ViewInfo = V;
-    type Material = M;
-    type Camera = ();
-
-    fn draw<H, S>(&self, phase: &mut H, _: &(), stream: &mut S)
-            -> Result<::FailCount, ::Error> where
-        H: gfx_phase::AbstractPhase<R, Self::Material, Self::ViewInfo>,
-        S: gfx::Stream<R>
-    {
-        let mut fail = 0;
-        // enqueue entities
-        for e in self {
-            match phase.enqueue(e.mesh, e.slice, e.material, &e.view_info) {
-                Ok(true) => (),
-                Ok(false) => fail += 1,
-                Err(e) => return Err(::Error::Batch(e)),
-            }
-        }
-        // flush into the renderer
-        match phase.flush(stream) {
-            Ok(()) => Ok(fail),
-            Err(e) => Err(::Error::Flush(e)),
-        }
-    }
-}*/
 
 /// Draw culled entities, specified by an iterator.
 pub fn draw<'a, R, M, V, I, H, S>(entities: I, phase: &mut H, stream: &mut S)

--- a/src/scene/lib.rs
+++ b/src/scene/lib.rs
@@ -11,7 +11,7 @@ use std::marker::PhantomData;
 
 mod cull;
 
-pub use self::cull::{Culler, CullPhase, Frustum};
+pub use self::cull::{Culler, CullScene, Frustum};
 
 
 /// Scene drawing error.
@@ -149,10 +149,12 @@ impl<
         S: gfx::Stream<R>,
     {
         // enqueue entities
-        let num_fail = match phase.enqueue_all(self.entities.iter(), &self.world, camera) {
-            Ok(num) => num,
-            Err(e) => return Err(Error::Batch(e)),
-        };
+        //let num_fail = match phase.enqueue_all(self.entities.iter(), &self.world, camera) {
+        //    Ok(num) => num,
+        //    Err(e) => return Err(Error::Batch(e)),
+        //};
+        //TODO!
+        let num_fail = 0;
         // flush into the renderer
         match phase.flush(stream) {
             Ok(()) => Ok(num_fail),

--- a/src/scene/lib.rs
+++ b/src/scene/lib.rs
@@ -30,15 +30,15 @@ pub type FailCount = usize;
 pub trait AbstractScene<R: gfx::Resources> {
     /// A type of the view information.
     type ViewInfo;
-    /// A type of the entity.
-    type Entity;
+    /// A type of the material.
+    type Material;
     /// A type of the camera.
     type Camera;
 
     /// Draw the contents of the scene with a specific phase into a stream.
     fn draw<H, S>(&self, &mut H, &Self::Camera, &mut S)
             -> Result<FailCount, Error> where
-        H: gfx_phase::AbstractPhase<R, Self::Entity, Self::ViewInfo>,
+        H: gfx_phase::AbstractPhase<R, Self::Material, Self::ViewInfo>,
         S: gfx::Stream<R>;
 }
 
@@ -73,15 +73,6 @@ pub struct Entity<R: gfx::Resources, M, W: World, B> {
     pub skeleton: Option<W::SkeletonPtr>,
     /// Associated spatial bound of the entity.
     pub bound: B,
-}
-
-impl<R: gfx::Resources, M: gfx_phase::Material, W: World, B> gfx_phase::Entity<R, M> for Entity<R, M, W, B> {
-    fn get_material(&self) -> &M {
-        &self.material
-    }
-    fn get_mesh(&self) -> (&gfx::Mesh<R>, &gfx::Slice<R>) {
-        (&self.mesh, &self.slice)
-    }
 }
 
 /// A simple camera with generic projection and spatial relation.
@@ -149,12 +140,12 @@ impl<
     V: ViewInfo<W::Scalar, W::Transform>,
 > AbstractScene<R> for Scene<R, M, W, B, P, V> {
     type ViewInfo = V;
-    type Entity = Entity<R, M, W, B>;
+    type Material = M;
     type Camera = Camera<P, W::NodePtr>;
 
     fn draw<H, S>(&self, phase: &mut H, camera: &Camera<P, W::NodePtr>,
             stream: &mut S) -> Result<FailCount, Error> where
-        H: gfx_phase::AbstractPhase<R, Entity<R, M, W, B>, V>,
+        H: gfx_phase::AbstractPhase<R, M, V>,
         S: gfx::Stream<R>,
     {
         // enqueue entities


### PR DESCRIPTION
Closes #26 

We can't actually use it in pipelines unless we make them to work with `gfx_scene::Scene` directly instead of `gfx_scene::AbstractScene`. One way to get it would be to have 2 `draw` methods in the pipeline: one for the abstract scene, and one for the regular scene that by default will just call the abstract scene variant. This way, a pipeline might be able to optimize the second code path using its own culling.